### PR TITLE
Fix multiple Smarkets instances

### DIFF
--- a/smarkets/clients.py
+++ b/smarkets/clients.py
@@ -5,8 +5,6 @@
 # http://www.opensource.org/licenses/mit-license.php
 import logging
 
-from itertools import chain
-
 import smarkets.eto.piqi_pb2 as eto
 import smarkets.seto.piqi_pb2 as seto
 


### PR DESCRIPTION
If you have more than one client, their Callback objects are the same.

```
>>> import smarkets.clients
>>> a = smarkets.clients.Smarkets('_')
>>> b = smarkets.clients.Smarkets('_')
>>> def h(msg): print repr(("client a received", msg))
... 
>>> a.add_handler('seto.http_found', h)

# pretend b is connected and got a message...
>>> b.callbacks['seto.http_found']('example_message')
('client a received', 'example_message')
```
