### PR TITLE
Fix flake8 and pin versions

### DIFF
--- a/requirements-dev-base.txt
+++ b/requirements-dev-base.txt
@@ -3,8 +3,8 @@ babel
 coverage==3.7.1
 decorator
 eventlet
-flake8
-flake8-blind-except
+flake8==3.2.0
+flake8-blind-except==0.1.1
 # Lower bound since we use the the smarkets style
 flake8-import-order>=0.7
 injector

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ class SmarketsProtocolClean(clean.clean):
         # Call the parent class clean command
         clean.clean.run(self)
 
+
 readme_path = join(PROJECT_ROOT, 'README.rst')
 
 with io.open(readme_path, encoding='utf-8') as f:

--- a/smarkets/__init__.py
+++ b/smarkets/__init__.py
@@ -10,4 +10,5 @@ def private(something):
     something.__private__ = True
     return something
 
+
 __all__ = ()

--- a/smarkets/string.py
+++ b/smarkets/string.py
@@ -30,6 +30,7 @@ def native_str_result(function, *args, **kwargs):
     '''
     return n(function(*args, **kwargs))
 
+
 _camel_case_re = re.compile('([A-Z]+)')
 
 

--- a/smarkets/uuid.py
+++ b/smarkets/uuid.py
@@ -43,6 +43,7 @@ class UuidTag(UuidTagBase):  # pylint: disable=E1001
         "Splits a number into the ID and tag"
         return divmod(number, cls.tag_mult)
 
+
 TAGS = (
     UuidTag('Account', int('acc1', 16), 'a'),
     UuidTag('ContractGroup', int('c024', 16), 'm'),


### PR DESCRIPTION
Build failed after 5b6fdca, because newly released
version 3.2.0 of flake8 was used, which detects
more E305 in our code. Before we used flake8 3.0.4 so these
E305 were not detected (but still existed in our code).

This commit fixes the newly discovered E305 instances
and also pins version of flake8 and its extension
flake8-blind-except, so that in the future we don't
have a build failure because of flake8 unrelated
changes (like in 5b6fdca).