### PR TITLE
Fix travis ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     # We need protobuf compiler 2.6+, 2.4 produces Python files incompatible
     # with Python 3
     #
-    - sudo sh -c "echo deb http://archive.ubuntu.com/ubuntu vivid main >> /etc/apt/sources.list"
+    - sudo sh -c "echo deb http://archive.ubuntu.com/ubuntu xenial main >> /etc/apt/sources.list"
     - sudo apt-get update -qq
     - sudo apt-get install -qq protobuf-compiler libprotobuf-dev
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ flake8==3.2.0
 flake8-blind-except==0.1.1
 # Lower bound since we use the the smarkets style
 flake8-import-order>=0.7
-injector
+# Injector seems to have dropped py2 compat above this version
+injector==0.10.1
 iso8601
 nose==1.3.0
 nose-ignore-docstring


### PR DESCRIPTION
Base ubuntu image is newer already, don't need to try to\
install protobuf stuff from the "future".