### PR TITLE
Requirements fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+9.4.2
+-----
+- Explicitly depend on pytz
+
 9.4.1
 -----
 - Minor compatibility bump

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ sdict = {
         'decorator',
         'iso8601',
         'protobuf==3.0.0b2',
+        'pytz',
         'six',
     ],
     'zip_safe': False,

--- a/smarkets/__init__.py
+++ b/smarkets/__init__.py
@@ -3,7 +3,7 @@
 # This module is released under the MIT License:
 # http://www.opensource.org/licenses/mit-license.php
 
-__version__ = '9.4.1'
+__version__ = '9.4.2'
 
 
 def private(something):


### PR DESCRIPTION
This is imported in `smarkets/datetime.py` so we should explicitly depend on it.